### PR TITLE
fix: remove title over event images

### DIFF
--- a/src/components/home/event-card.tsx
+++ b/src/components/home/event-card.tsx
@@ -34,14 +34,14 @@ export const EventCard = ({
           height="1000"
           src={imageUrl}
         />
-        <h1
+        {/* <h1
           className={cn(
             "absolute bottom-6 left-6 z-40 text-4xl font-bold bg-gradient-to-r from-[#31B553] to-[#0AA294] bg-clip-text text-transparent group-hover:scale-125",
             titleClassName
           )}
         >
           {title}
-        </h1>
+        </h1> */}
       </div>
     </div>
   );


### PR DESCRIPTION
Removed the text that overlays above the event images.
![Screenshot 2024-08-18 at 12 48 02 PM](https://github.com/user-attachments/assets/1e434248-e110-4267-adee-721a923b8f0d)
